### PR TITLE
Swapping out toJSON with raw models for .paginate

### DIFF
--- a/src/Bumblebee/index.js
+++ b/src/Bumblebee/index.js
@@ -52,7 +52,7 @@ class Bumblebee {
 
   paginate (data, transformer = null) {
     this._setData('Collection', data.rows)
-    this._pagination = data.pages;
+    this._pagination = data.pages
 
     if (transformer) {
       this.transformWith(transformer)

--- a/src/Bumblebee/index.js
+++ b/src/Bumblebee/index.js
@@ -51,15 +51,8 @@ class Bumblebee {
   }
 
   paginate (data, transformer = null) {
-    if (!(data.toJSON instanceof Function)) {
-      throw new Error('The paginate() method only accepts query builder results with pagination.')
-    }
-
-    let paginatedData = data.toJSON()
-    this._setData('Collection', paginatedData.data)
-
-    delete paginatedData.data
-    this._pagination = paginatedData
+    this._setData('Collection', data.rows)
+    this._pagination = data.pages;
 
     if (transformer) {
       this.transformWith(transformer)


### PR DESCRIPTION
I noticed that when using paginate, models are converted to JSON before being passed into the transformer. This caused a few issues such as unable to load relations and unable to call methods on the model.

This PR removes the need for toJSON to be called and appears to fully work when using the Vanilla serializer shipped with Lucid.