### PR TITLE
Added support for multi-part includes

### DIFF
--- a/src/Bumblebee/TransformerAbstract.js
+++ b/src/Bumblebee/TransformerAbstract.js
@@ -63,7 +63,12 @@ class TransformerAbstract {
   }
 
   async callIncludeFunction (include, parentScope, data) {
-    let includeName = `include${include.charAt(0).toUpperCase()}${include.slice(1)}`
+    // Split on underscores and hyphens to properly support multi-part includes
+    let formattedInclude = include.split(/[_|-]/)
+      .map(word => word[0].toUpperCase() + word.substr(1).toLowerCase())
+      .join('')
+
+    let includeName = `include${formattedInclude}`
 
     if (!(this[includeName] instanceof Function)) {
       throw new Error(`A method called '${includeName}' could not be found in '${this.constructor.name}'`)


### PR DESCRIPTION
Currently, when you use `?include=posts`, bumblebee looks for `includePosts`. 

However, when you include something seperated by a hyphen or underscore such as `?include=mutual_interests` a function with name of `includeMutual_interests` is expected.

This PR adds support for these to expect `includeMutualInterests` instead!

(tests passing this time! 😀)