### PR TITLE
Ensuring pagination data is forced to integers

### DIFF
--- a/src/Bumblebee/index.js
+++ b/src/Bumblebee/index.js
@@ -52,11 +52,13 @@ class Bumblebee {
 
   paginate (data, transformer = null) {
     this._setData('Collection', data.rows)
-    
-    let paginationData = data.pages;
+
+    let paginationData = data.pages
 
     // Ensure the pagination keys are integers
-    Object.keys(paginationData).forEach((key) => paginationData[key] = parseInt(paginationData[key]))
+    Object.keys(paginationData).forEach((key) => {
+      paginationData[key] = parseInt(paginationData[key])
+    })
 
     this._pagination = paginationData
 

--- a/src/Bumblebee/index.js
+++ b/src/Bumblebee/index.js
@@ -52,7 +52,13 @@ class Bumblebee {
 
   paginate (data, transformer = null) {
     this._setData('Collection', data.rows)
-    this._pagination = data.pages
+    
+    let paginationData = data.pages;
+
+    // Ensure the pagination keys are integers
+    Object.keys(paginationData).forEach((key) => paginationData[key] = parseInt(paginationData[key]))
+
+    this._pagination = paginationData
 
     if (transformer) {
       this.transformWith(transformer)

--- a/test/pagination.spec.js
+++ b/test/pagination.spec.js
@@ -41,4 +41,25 @@ test.group('Pagination', () => {
       data: [{id: 3}, {id: 7}]
     })
   })
+
+  test('ensure integer pagination data', async (assert) => {
+    // Overwrite with a string to ensure transformation
+    data.pages.page = '2'
+
+    let transformed = await Bumblebee.create()
+      .paginate(data)
+      .transformWith(d => ({ id: d.item_id }))
+      .serializeWith('data')
+      .toArray()
+
+    assert.deepEqual(transformed, {
+      pagination: {
+        total: 5,
+        perPage: 20,
+        page: 2,
+        lastPage: 1
+      },
+      data: [{id: 3}, {id: 7}]
+    })
+  })
 })


### PR DESCRIPTION
My mobile devs were moaning that sometimes paging was coming back as strings (this is actually adonis's fault, but it doesn't need to care as much as bumblebee!)

This forces to integers

before:
```json
{
  "pagination": {
    "total": 243,
    "perPage": 20,
    "page": "1",
    "lastPage": 13
  },
```

after:
```json
{
  "pagination": {
    "total": 243,
    "perPage": 20,
    "page": 1,
    "lastPage": 13
  },
```