### PR TITLE
added support for transformers namespacing

### DIFF
--- a/src/Commands/MakeTransformer.js
+++ b/src/Commands/MakeTransformer.js
@@ -1,4 +1,4 @@
-'user strict'
+"user strict";
 
 /**
  * adonis-bumblebee
@@ -7,25 +7,25 @@
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
-*/
+ */
 
-const { Command } = require('@adonisjs/ace')
-const { join } = require('path')
-const _ = require('lodash')
+const { Command } = require("@adonisjs/ace");
+const { join } = require("path");
+const _ = require("lodash");
 
 class MakeTransformer extends Command {
   /**
    * The signature for the Make command
    */
-  static get signature () {
-    return `make:transformer { name: Name of Transformer }`
+  static get signature() {
+    return `make:transformer { name: Name of Transformer }`;
   }
 
   /**
    * The description for the command
    */
-  static get description () {
-    return 'Make a new transformer for adonis-bumblebee'
+  static get description() {
+    return "Make a new transformer for adonis-bumblebee";
   }
 
   /**
@@ -33,18 +33,28 @@ class MakeTransformer extends Command {
    *
    * @param {*} name
    */
-  async handle ({ name }) {
+  async handle({ name }) {
     try {
-      name = this.getName(name)
-      const templatePath = join(__dirname, '../../templates/Transformer.mustache')
-      const templateContent = await this.readFile(templatePath, 'utf-8')
-      const filePath = join('app/Transformers', name) + '.js'
+      let directories = name.split("/");
+      name = this.getName(directories[directories.length - 1]);
+      directories.splice(-1, 1);
+      directories = directories.join("/");
+      const templatePath = join(
+        __dirname,
+        "../../templates/Transformer.mustache"
+      );
 
-      await this.generateFile(filePath, templateContent, { name })
+      const templateContent = await this.readFile(templatePath, "utf-8");
+      const dirpath = join("app/Transformers", directories);
+      const filePath = join(dirpath, name) + ".js";
 
-      console.log(`${this.icon('success')} ${this.chalk.green('create')}  ${filePath}`)
+      await this.generateFile(filePath, templateContent, { name });
+
+      console.log(
+        `${this.icon("success")} ${this.chalk.green("create")}  ${filePath}`
+      );
     } catch ({ message }) {
-      this.error(message)
+      this.error(message);
     }
   }
 
@@ -53,9 +63,11 @@ class MakeTransformer extends Command {
    *
    * @param {*} name
    */
-  getName (name) {
-    return _.upperFirst(_.camelCase(name.replace('Transformer', ''))) + 'Transformer'
+  getName(name) {
+    return (
+      _.upperFirst(_.camelCase(name.replace("Transformer", ""))) + "Transformer"
+    );
   }
 }
 
-module.exports = MakeTransformer
+module.exports = MakeTransformer;


### PR DESCRIPTION
Now, users can create namespaced transformers by specifying the subfolder using '/'.

e.g: `adonis make:transformer Users/User`

// the output file would be
`app/Transformers/Users/UserTransformer.js`