### PR TITLE
feat(variant): different transformer variants can be used

### DIFF
--- a/src/Bumblebee/Manager.js
+++ b/src/Bumblebee/Manager.js
@@ -66,6 +66,17 @@ class Manager {
   }
 
   /**
+   * Allowes setting a custom recursion limit
+   *
+   * @param {*} limit
+   */
+  setRecursionLimit (limit) {
+    this._recursionLimit = limit
+
+    return this
+  }
+
+  /**
    * Create a serializer
    *
    * @param {*} serializer
@@ -146,17 +157,6 @@ class Manager {
 
     // add all parsed includes to the set of requested includes
     parsed.forEach(this.requestedIncludes.add, this.requestedIncludes)
-  }
-
-  /**
-   * Allowes setting a custom recursion limit
-   *
-   * @param {*} limit
-   */
-  setRecursionLimit (limit) {
-    this._recursionLimit = limit
-
-    return this
   }
 
   /**

--- a/src/Bumblebee/Resources/ResourceAbstract.js
+++ b/src/Bumblebee/Resources/ResourceAbstract.js
@@ -11,10 +11,14 @@ class ResourceAbstract {
    * Constractor for the ResourceAbstract
    * This allowes to set data and transformer while creating an instance
    */
-  constructor (data, transformer) {
+  constructor (data, trans) {
     this.data = data
-    this.transformer = transformer
     this.meta = null
+
+    let { transformer, variant } = this._separateTransformerAndVariation(trans)
+
+    this.transformer = transformer
+    this.variant = variant
   }
 
   /**
@@ -74,6 +78,48 @@ class ResourceAbstract {
    */
   getPagination () {
     return this.pagination
+  }
+
+  /**
+   * Set the transformer variant to be used for this resource
+   *
+   * @param {Object} pagination
+   */
+  setVariant (variant) {
+    if (variant) {
+      this.variant = variant
+    }
+
+    return this
+  }
+
+  /**
+   * Returns the transformer variant
+   */
+  getVariant () {
+    return this.variant
+  }
+
+  /**
+   * When a transformer string is passed with a variation defined in dot-notation
+   * we will split the string into transformer and variant
+   */
+  _separateTransformerAndVariation (transformerString) {
+    // This feature is only available when a string binding is used
+    if (typeof transformerString !== 'string') {
+      return { transformer: transformerString, variant: null }
+    }
+
+    let regex = /(.*)\.(.*)/
+
+    let matches = transformerString.match(regex)
+
+    // if the string did not contain a variation use the
+    // transformerString is used and the variation is set to null
+    let transformer = matches ? matches[1] : transformerString
+    let variant = matches ? matches[2] : null
+
+    return { transformer, variant }
   }
 }
 

--- a/src/Bumblebee/TransformerAbstract.js
+++ b/src/Bumblebee/TransformerAbstract.js
@@ -28,7 +28,7 @@ class TransformerAbstract {
    * Implementation required
    */
   transform () {
-    throw new Error('You have to implement the method transform!')
+    throw new Error('You have to implement the method transform or specify a variant when calling the transformer!')
   }
 
   /**

--- a/src/Bumblebee/index.js
+++ b/src/Bumblebee/index.js
@@ -25,6 +25,7 @@ class Bumblebee {
     instance._data = data
     instance._dataType = instance._determineDataType(data)
     instance._transformer = transformer
+    instance._variant = null
 
     // set pagination, context and meta properties to null
     instance._pagination = null
@@ -144,6 +145,17 @@ class Bumblebee {
   }
 
   /**
+   * Set the transformer variant
+   *
+   * @param {String} variant
+   */
+  usingVariant (variant) {
+    this._variant = variant
+
+    return this
+  }
+
+  /**
    * Allows you to set the adonis context if you are not
    * using the 'transform' object from the http context.
    *
@@ -230,6 +242,7 @@ class Bumblebee {
 
     resourceInstance.setMeta(this._meta)
     resourceInstance.setPagination(this._pagination)
+    resourceInstance.setVariant(this._variant)
 
     return resourceInstance
   }

--- a/test/transformer-variants.spec.js
+++ b/test/transformer-variants.spec.js
@@ -1,0 +1,81 @@
+'use strict'
+
+/**
+ * adonis-bumblebee
+ *
+ * (c) Ralph Huwiler <ralph@huwiler.rocks>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+*/
+
+const test = require('japa')
+const { ioc } = require('@adonisjs/fold')
+
+const Bumblebee = require('../src/Bumblebee')
+const TransformerAbstract = require('../src/Bumblebee/TransformerAbstract')
+
+class IDTransformer extends TransformerAbstract {
+  transformVariant1 (model) {
+    return {
+      id: model.item_id
+    }
+  }
+
+  transformVariant2 (model) {
+    return {
+      identifier: model.item_id
+    }
+  }
+}
+
+test.group('Transformer Variants', () => {
+  test('a specific variant can be used for the transformer method', async (assert) => {
+    let data = { item_id: 3 }
+
+    let transformedVariant1 = await Bumblebee.create()
+      .item(data)
+      .transformWith(IDTransformer)
+      .usingVariant('variant1')
+      .toJSON()
+
+    assert.equal(transformedVariant1.id, 3)
+
+    let transformedVariant2 = await Bumblebee.create()
+      .item(data)
+      .transformWith(IDTransformer)
+      .usingVariant('variant2')
+      .toJSON()
+
+    assert.equal(transformedVariant2.identifier, 3)
+  })
+
+  test('a transformer can be defined using dot-notation', async (assert) => {
+    ioc.bind('App/Transformers/IDTransformer', () => new IDTransformer())
+
+    let data = { item_id: 3 }
+
+    let transformedVariant1 = await Bumblebee.create()
+      .item(data)
+      .transformWith('App/Transformers/IDTransformer.variant1')
+      .toJSON()
+
+    assert.equal(transformedVariant1.id, 3)
+  })
+
+  test('an error is thrown if an invalid variant is passed', async (assert) => {
+    assert.plan(1)
+
+    let data = { item_id: 3 }
+
+    try {
+      await Bumblebee.create()
+        .item(data)
+        .transformWith(IDTransformer)
+        .usingVariant('variantX')
+        .toJSON()
+    } catch ({ message }) {
+      assert.equal(message, 'A transformer method \'transformVariantX\' could not be found in \'IDTransformer\'')
+    }
+  })
+})

--- a/test/transformer-variants.spec.js
+++ b/test/transformer-variants.spec.js
@@ -63,6 +63,22 @@ test.group('Transformer Variants', () => {
     assert.equal(transformedVariant1.id, 3)
   })
 
+  test('variants can be used in shorthand form', async (assert) => {
+    ioc.bind('App/Transformers/IDTransformer', () => new IDTransformer())
+
+    let data = { item_id: 3 }
+
+    let transformedVariant1 = await Bumblebee.create()
+      .item(data, 'App/Transformers/IDTransformer.variant1')
+
+    assert.equal(transformedVariant1.id, 3)
+
+    let transformedVariant2 = await Bumblebee.create()
+      .collection([data], 'App/Transformers/IDTransformer.variant2')
+
+    assert.equal(transformedVariant2[0].identifier, 3)
+  })
+
   test('an error is thrown if an invalid variant is passed', async (assert) => {
     assert.plan(1)
 

--- a/test/transformer.spec.js
+++ b/test/transformer.spec.js
@@ -102,7 +102,7 @@ test.group('Transformer', () => {
         .transformWith(InvalidTransformer)
         .toJSON()
     } catch ({ message }) {
-      assert.equal(message, 'You have to implement the method transform!')
+      assert.equal(message, 'You have to implement the method transform or specify a variant when calling the transformer!')
     }
   })
 


### PR DESCRIPTION
This PR will add the option to define multiple transform method in a Transformer class. These other transform methods are referred to as "variants".

- If no variant is defined, the default "transform" method will be used.
- A variant must be named as follows: `transform{VariantName}`
- A variant can be used by specifying it using the `usingVariant` method
- A variant can also be specified using dot-notation when passing the transformer as a string: `App/Transformers/IDTransformer.variant1`